### PR TITLE
Add --output-find-links options

### DIFF
--- a/freezerequirements/cli.py
+++ b/freezerequirements/cli.py
@@ -66,8 +66,7 @@ def main():
 @click.option('--output-index-url', help='Add an --index-url in the generated '
               'requirements file', metavar='URL')
 @click.option('--output-find-links', multiple=True, metavar='URL',
-              help='Add a --find-links in the generated requirements file', )
-              metavar='URL')
+              help='Add a --find-links in the generated requirements file')
 @click.option('--loose', 'loose_packages', multiple=True, metavar='PACKAGE',
               help='Do not specify version for PACKAGE in the output '
               'requirements file(s)')


### PR DESCRIPTION
This options is very similar to the existing --output-index-url option.
However, in our case we have a webserver with only a few additional
packages, and we don't mirror all the packages that we need from pypi.
In this case, we need to add a --find-index options to the requirements
file, not a --index-url.
