### PR TITLE
Make StringWithAttrs py3k compatible

### DIFF
--- a/freezerequirements/utils.py
+++ b/freezerequirements/utils.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from distutils.version import LooseVersion
 from itertools import takewhile
 import glob
+import six
 
 import sh
 from setuptools.package_index import distros_for_filename
@@ -136,7 +137,7 @@ def group_and_select_packages(packages_groups):
     return dict(ret)
 
 
-class StringWithAttrs(unicode):
+class StringWithAttrs(six.text_type):
     '''
     An unicode subclass, to be able to add attributes.
     '''

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ version = '0.5.1'
 install_requires = [
     'click',
     'sh',
+    'six',
 ]
 
 


### PR DESCRIPTION
freeze-requirements did not work with py3k. I think this change should make at least the `freeze --merged-requirements` function work with both.